### PR TITLE
Add suitable default to template args

### DIFF
--- a/include/cpppid/controllers/derivative.hpp
+++ b/include/cpppid/controllers/derivative.hpp
@@ -6,7 +6,7 @@
 namespace cpppid {
     namespace controllers {
 
-        template <typename Kd, typename TimeInterval, typename PreviousError>
+        template <typename Kd = double, typename TimeInterval = int, typename PreviousError = double>
         class derivative {
             public:
                 derivative(Kd factor, TimeInterval interval, PreviousError initial_error = PreviousError{})

--- a/include/cpppid/controllers/integral.hpp
+++ b/include/cpppid/controllers/integral.hpp
@@ -6,7 +6,7 @@
 namespace cpppid {
     namespace controllers {
 
-        template <typename Ki, typename TimeInterval, typename AccumulatedError>
+        template <typename Ki = double, typename TimeInterval = int, typename AccumulatedError = double>
         class integral {
             public:
                 integral(Ki factor, TimeInterval interval)

--- a/include/cpppid/controllers/proportional.hpp
+++ b/include/cpppid/controllers/proportional.hpp
@@ -6,7 +6,7 @@
 namespace cpppid {
     namespace controllers {
 
-        template <typename Kp>
+        template <typename Kp = double>
         class proportional {
             public:
                 proportional(Kp factor) : m_factor{std::move(factor)} {}

--- a/test/composer_adder_test.cpp
+++ b/test/composer_adder_test.cpp
@@ -37,3 +37,19 @@ TEST(CppPIDadder, shouldComposeToPID) {
     EXPECT_NEAR(ctrl_pid(1), -772.1, 1);
     EXPECT_NEAR(ctrl_pid(100), 784.7, 1);
 }
+
+TEST(CppPIDadder, shouldComposeToPIDWithDefaultTemplateArg) {
+    auto ctrl_proportional = proportional<>{2.5};
+    auto ctrl_derivative = derivative<>{5.4, 1};
+    auto ctrl_integral = integral<>{7.8, 1};
+
+    auto ctrl_pid = adder<proportional<>, derivative<>, integral<>>{
+        ctrl_proportional, ctrl_derivative, ctrl_integral
+    };
+
+    EXPECT_NEAR(ctrl_pid(-100), -1570.0, 1);
+    EXPECT_NEAR(ctrl_pid(-1), -255.7, 1);
+    EXPECT_NEAR(ctrl_pid(0), -782.4, 1);
+    EXPECT_NEAR(ctrl_pid(1), -772.1, 1);
+    EXPECT_NEAR(ctrl_pid(100), 784.7, 1);
+}

--- a/test/controller_derivative_test.cpp
+++ b/test/controller_derivative_test.cpp
@@ -18,3 +18,9 @@ TEST(CppPIDderivative, shouldDefaultToInitialErrorOfZero) {
 
     EXPECT_EQ(ctrl(2), 4);
 }
+
+TEST(CppPIDderivative, shouldInferTemplateArg) {
+    auto ctrl = derivative<>{2.0, 1};
+
+    EXPECT_DOUBLE_EQ(ctrl(1), 2.0);
+}

--- a/test/controller_integral_test.cpp
+++ b/test/controller_integral_test.cpp
@@ -12,3 +12,9 @@ TEST(CppPIDintegral, shouldReturnProportionalToTheIntegralOfTheError) {
     EXPECT_NEAR(ctrl(14), 114.000, 0.001);
     EXPECT_NEAR(ctrl(3), 132.000, 0.001);
 }
+
+TEST(CppPIDintegral, shouldInferTemplateArg) {
+    auto ctrl = integral<>{2.0, 1};
+
+    EXPECT_DOUBLE_EQ(ctrl(1), 2.0);
+}

--- a/test/controller_proportional_test.cpp
+++ b/test/controller_proportional_test.cpp
@@ -29,3 +29,9 @@ TEST(CppPIDproportional, shouldReturnDoubleIfErrorIsDouble) {
     EXPECT_DOUBLE_EQ(ctrl(0.0), 0.0);
     EXPECT_DOUBLE_EQ(ctrl(1.5), 4.5);
 }
+
+TEST(CppPIDproportional, shouldInferTemplateArg) {
+    auto ctrl = proportional<>{2.0};
+
+    EXPECT_DOUBLE_EQ(ctrl(1), 2.0);
+}


### PR DESCRIPTION
That might cover most of the common cases, for the factors, errors and time units.

So the client code doesn't need to explicit set them.