### PR TITLE
Upgrade from C++14 to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_compile_features(${PROJECT_NAME}
 	INTERFACE
-		cxx_std_14
+		cxx_std_17
 )
 
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cpppid
-A composable library based on templates to implement control loops in C++14.
+A composable library based on templates to implement control loops in C++17.
 
 By composing basic control functions, for instance:
 * Proportional

--- a/include/cpppid/composers/adder.hpp
+++ b/include/cpppid/composers/adder.hpp
@@ -9,7 +9,7 @@
 namespace cpppid {
     namespace composers {
 
-        template <typename TotalOutput, typename... Controllers>
+        template <typename TotalOutput = double, typename... Controllers>
         class adder {
             using ControllersCollection = std::tuple<Controllers...>;
 

--- a/include/cpppid/composers/adder.hpp
+++ b/include/cpppid/composers/adder.hpp
@@ -14,7 +14,7 @@ namespace cpppid {
             using ControllersCollection = std::tuple<Controllers...>;
 
             public:
-                adder(Controllers... controllers)
+                explicit adder(Controllers... controllers)
                     : m_controllers{std::make_tuple(controllers...)} {}
 
                 template <typename Error>

--- a/include/cpppid/controllers/derivative.hpp
+++ b/include/cpppid/controllers/derivative.hpp
@@ -9,7 +9,7 @@ namespace cpppid {
         template <typename Kd = double, typename TimeInterval = int, typename PreviousError = double>
         class derivative {
             public:
-                derivative(Kd factor, TimeInterval interval, PreviousError initial_error = PreviousError{})
+                explicit derivative(Kd factor, TimeInterval interval, PreviousError initial_error = PreviousError{})
                     : m_factor{std::move(factor)},
                       m_interval{std::move(interval)},
                       m_previousError{std::move(initial_error)} {}

--- a/include/cpppid/controllers/integral.hpp
+++ b/include/cpppid/controllers/integral.hpp
@@ -9,7 +9,7 @@ namespace cpppid {
         template <typename Ki = double, typename TimeInterval = int, typename AccumulatedError = double>
         class integral {
             public:
-                integral(Ki factor, TimeInterval interval)
+                explicit integral(Ki factor, TimeInterval interval)
                     : m_factor{std::move(factor)},
                       m_interval{std::move(interval)},
                       m_accumulatedError{AccumulatedError{}} {}

--- a/include/cpppid/controllers/proportional.hpp
+++ b/include/cpppid/controllers/proportional.hpp
@@ -9,7 +9,7 @@ namespace cpppid {
         template <typename Kp = double>
         class proportional {
             public:
-                proportional(Kp factor) : m_factor{std::move(factor)} {}
+                explicit proportional(Kp factor) : m_factor{std::move(factor)} {}
 
                 template <typename Error>
                 auto operator()(Error const& current_error) {

--- a/test/composer_adder_test.cpp
+++ b/test/composer_adder_test.cpp
@@ -39,11 +39,11 @@ TEST(CppPIDadder, shouldComposeToPID) {
 }
 
 TEST(CppPIDadder, shouldComposeToPIDWithDefaultTemplateArg) {
-    auto ctrl_proportional = proportional<>{2.5};
-    auto ctrl_derivative = derivative<>{5.4, 1};
-    auto ctrl_integral = integral<>{7.8, 1};
+    auto ctrl_proportional = proportional{2.5};
+    auto ctrl_derivative = derivative{5.4, 1};
+    auto ctrl_integral = integral{7.8, 1};
 
-    auto ctrl_pid = adder<proportional<>, derivative<>, integral<>>{
+    auto ctrl_pid = adder{
         ctrl_proportional, ctrl_derivative, ctrl_integral
     };
 

--- a/test/controller_derivative_test.cpp
+++ b/test/controller_derivative_test.cpp
@@ -20,7 +20,7 @@ TEST(CppPIDderivative, shouldDefaultToInitialErrorOfZero) {
 }
 
 TEST(CppPIDderivative, shouldInferTemplateArg) {
-    auto ctrl = derivative<>{2.0, 1};
+    auto ctrl = derivative{2.0, 1};
 
     EXPECT_DOUBLE_EQ(ctrl(1), 2.0);
 }

--- a/test/controller_integral_test.cpp
+++ b/test/controller_integral_test.cpp
@@ -14,7 +14,7 @@ TEST(CppPIDintegral, shouldReturnProportionalToTheIntegralOfTheError) {
 }
 
 TEST(CppPIDintegral, shouldInferTemplateArg) {
-    auto ctrl = integral<>{2.0, 1};
+    auto ctrl = integral{2.0, 1};
 
     EXPECT_DOUBLE_EQ(ctrl(1), 2.0);
 }

--- a/test/controller_proportional_test.cpp
+++ b/test/controller_proportional_test.cpp
@@ -31,7 +31,7 @@ TEST(CppPIDproportional, shouldReturnDoubleIfErrorIsDouble) {
 }
 
 TEST(CppPIDproportional, shouldInferTemplateArg) {
-    auto ctrl = proportional<>{2.0};
+    auto ctrl = proportional{2.0};
 
     EXPECT_DOUBLE_EQ(ctrl(1), 2.0);
 }


### PR DESCRIPTION
To use newest features, like template type deduction for constructors.

Also marks constructor as explicit, and adds default template type for adder's totaloutput.

**NOTE:**
That enforces clients to use compilers that support C++17.