### PR TITLE
Add new controller: onoff

### DIFF
--- a/include/cpppid/composers/adder.hpp
+++ b/include/cpppid/composers/adder.hpp
@@ -22,7 +22,7 @@ namespace cpppid {
                     auto total_output = TotalOutput{};
 
                     utils::each(m_controllers, [&total_output, &current_error](auto & ctrl) {
-                        total_output += TotalOutput{ctrl(current_error)};
+                        total_output += static_cast<TotalOutput>(ctrl(current_error));
                     });
 
                     return total_output;

--- a/include/cpppid/controllers/onoff.hpp
+++ b/include/cpppid/controllers/onoff.hpp
@@ -1,0 +1,39 @@
+#ifndef ONOFF_HPP
+#define ONOFF_HPP
+
+#include <utility>
+
+namespace cpppid {
+    namespace controllers {
+
+        template <typename InputLimit, typename OutputLimit>
+        struct boundary {
+            InputLimit input;
+            OutputLimit output;
+        };
+
+        template <typename InputLimit = double, typename OutputLimit = double>
+        class onoff {
+            public:
+                explicit onoff(boundary<InputLimit, OutputLimit> lower, boundary<InputLimit, OutputLimit> upper)
+                    : m_lower{std::move(lower)},
+                      m_upper{std::move(upper)} {}
+
+                template <typename Error>
+                auto operator()(Error const& current_error) {
+                    if (current_error < m_lower.input) {
+                        return m_lower.output;
+                    } else if (current_error > m_upper.input) {
+                        return m_upper.output;
+                    }
+                    return static_cast<OutputLimit>(current_error);
+                }
+
+            private:
+                boundary<InputLimit, OutputLimit> const m_lower;
+                boundary<InputLimit, OutputLimit> const m_upper;
+        };
+    }
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(cpppid_test
 
 target_compile_features(cpppid_test
 	PRIVATE
-		cxx_std_14
+		cxx_std_17
 )
 
 if (NOT MSVC)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(cpppid_test
 	controller_derivative_test.cpp
 	controller_integral_test.cpp
 	controller_proportional_test.cpp
+	controller_onoff_test.cpp
 
 	composer_adder_test.cpp
 )

--- a/test/controller_onoff_test.cpp
+++ b/test/controller_onoff_test.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "cpppid/controllers/onoff.hpp"
+
+using namespace cpppid::controllers;
+
+TEST(CppPIDonoff, shouldLimitTheErrorInARange) {
+    auto const lower_bound = boundary<double, double>{-10, -100};
+    auto const upper_bound = boundary<double, double>{10, 100};
+    auto ctrl = onoff{lower_bound, upper_bound};
+
+    EXPECT_EQ(ctrl(-10), -10);
+    EXPECT_EQ(ctrl(10), 10);
+    EXPECT_EQ(ctrl(0), 0);
+    EXPECT_EQ(ctrl(-11), -100);
+    EXPECT_EQ(ctrl(11), 100);
+}


### PR DESCRIPTION
That limits the error between two boundaries.

Also compiles the test using C++17 and small refactors.