### PR TITLE
Extract duplication from profiles and cleans up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,6 @@ ifndef PROFILE
 override PROFILE="../profiles/x86_64"
 endif
 
-ifndef RUNNER
-override RUNNER=
-endif
-
 .PHONY: all env-x86_64 env-x86_64-test env-x86_64-run env-armv7 env-armv7-test env-armv7-run test compile gen dep mk clean
 
 all: compile

--- a/profiles/armv7
+++ b/profiles/armv7
@@ -1,12 +1,3 @@
+include(common)
 [settings]
-os=Linux
-os_build=Linux
 arch=armv7
-arch_build=x86_64
-compiler=gcc
-compiler.version=8
-compiler.libcxx=libstdc++11
-build_type=Release
-[options]
-[build_requires]
-[env]

--- a/profiles/common
+++ b/profiles/common
@@ -1,0 +1,8 @@
+[settings]
+os=Linux
+os_build=Linux
+arch_build=x86_64
+compiler=gcc
+compiler.version=8
+compiler.libcxx=libstdc++11
+build_type=Release

--- a/profiles/x86_64
+++ b/profiles/x86_64
@@ -1,12 +1,3 @@
+include(common)
 [settings]
-os=Linux
-os_build=Linux
 arch=x86_64
-arch_build=x86_64
-compiler=gcc
-compiler.version=8
-compiler.libcxx=libstdc++11
-build_type=Release
-[options]
-[build_requires]
-[env]


### PR DESCRIPTION
- env: Remove unnecessary fallback for custom RUNNER.
- conan: Move duplication from profiles to profiles/common